### PR TITLE
Fixes #4: Highlighting breaks in anonymous fn inside arguments

### DIFF
--- a/package/Gleam.sublime-syntax
+++ b/package/Gleam.sublime-syntax
@@ -129,6 +129,7 @@ contexts:
       push: function_def_args
     - match: \)
       pop: true
+      push: main
 
   # Imports
   import:


### PR DESCRIPTION
Ensure that the body of the function is recognized as a separate context that includes necessary elements like variables, operators, etc...