### PR TITLE
Make `echo` a `keyword.other.gleam`

### DIFF
--- a/package/Gleam.sublime-syntax
+++ b/package/Gleam.sublime-syntax
@@ -162,7 +162,7 @@ contexts:
 
   # Keywords
   keyword:
-    - match: \b(as|assert|case|const|if|let|panic|todo|use)\b
+    - match: \b(as|assert|case|const|echo|if|let|panic|todo|use)\b
       scope: keyword.other.gleam
     - match: \b(opaque|pub)\b
       scope: storage.modifier.gleam
@@ -171,7 +171,7 @@ contexts:
     - match: \bfn\b
       scope: storage.type.function.gleam
     # Reserved for future use
-    - match: \b(auto|delegate|derive|echo|else|implement|macro|test)\b
+    - match: \b(auto|delegate|derive|else|implement|macro|test)\b
       scope: invalid.illegal.gleam
 
   # Numbers

--- a/tests/src/basics/syntax_test_keywords.gleam
+++ b/tests/src/basics/syntax_test_keywords.gleam
@@ -1,0 +1,10 @@
+// SYNTAX TEST "Packages/Gleam/package/Gleam.sublime-syntax"
+
+pub fn main() {
+  echo [1, 2, 3]
+  // <- keyword.other
+  //    ^ constant.numeric.decimal
+  //     ^ punctuation.separator
+  //       ^ constant.numeric.decimal
+  //        ^ punctuation.separator
+}


### PR DESCRIPTION
[Gleam 1.9.0](https://gleam.run/news/hello-echo-hello-git/#echo-debug-printing) introduces the `echo` keyword. This simply moves the keyword from the `invalid.illegal.gleam` scope to the `keyword.other.gleam` scope.

I couldn't find a syntax test file for keywords, so I added one with just `echo` in it as a start. The suite of syntax tests looks to still all pass (locally) with this change:

```
Success: 90448 assertions in 200 files passed
[Finished]
```